### PR TITLE
subscription callback removals, display of teams on user detail

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -225,6 +225,32 @@
         }
       },
       "schematics": {}
+    },
+    "shared": {
+      "projectType": "library",
+      "root": "libs/feature/shared",
+      "sourceRoot": "libs/feature/shared/src",
+      "prefix": "selise-start",
+      "architect": {
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "libs/feature/shared/tsconfig.lib.json",
+              "libs/feature/shared/tsconfig.spec.json"
+            ],
+            "exclude": ["**/node_modules/**", "!libs/feature/shared/**/*"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "options": {
+            "jestConfig": "libs/feature/shared/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      },
+      "schematics": {}
     }
   },
   "cli": {

--- a/apps/code-auditor/src/app/user/user-routing.module.ts
+++ b/apps/code-auditor/src/app/user/user-routing.module.ts
@@ -5,7 +5,8 @@ import {
   UsersComponent,
   UserDetailComponent,
   AddUserComponent,
-  AdminApprovalComponent
+  AdminApprovalComponent,
+  EditUserComponent
 } from '@selise-start/user';
 import { UserBaseComponent } from './user-base/user-base.component';
 import { AuthGuardGuard } from '@selise-start/auth';
@@ -26,12 +27,17 @@ const routes: Routes = [
       },
       {
         path: 'approval',
-        component: AdminApprovalComponent,
+        component: AdminApprovalComponent
+      },
+      {
+        path: ':id/edit-user',
+        pathMatch: 'full',
+        component: EditUserComponent
       },
       {
         path: ':id',
-        component: UserDetailComponent,
-      },
+        component: UserDetailComponent
+      }
     ]
   }
 ];
@@ -40,4 +46,5 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes), FeatureUserModule],
   exports: [RouterModule]
 })
-export class UserRoutingModule { }
+export class UserRoutingModule {
+}

--- a/db.json
+++ b/db.json
@@ -8,7 +8,10 @@
       "lastName": "yoezer",
       "confirmPassword": "kzoeps123",
       "role": "FE",
-      "memberOnTeams": [],
+      "memberOnTeams": [
+        2,
+        3
+      ],
       "approved": true,
       "id": 1
     },
@@ -20,12 +23,7 @@
       "lastName": "yoezer",
       "confirmPassword": "karma123",
       "role": "FE",
-      "memberOnTeams": [
-        {
-          "id": 3,
-          "name": "another one"
-        }
-      ],
+      "memberOnTeams": [],
       "approved": true,
       "admin": true,
       "id": 2
@@ -33,7 +31,9 @@
     {
       "email": "g@g.com",
       "password": "$2a$10$mXA2Q2Z2PiLZ5JNe6V0vKOMxUK4pwDRzWWGFFzCOUt.x6aj.CXdyi",
-      "memberOnTeams": [],
+      "memberOnTeams": [
+        1
+      ],
       "firstName": "g",
       "lastName": "g",
       "confirmPassword": "g12345",
@@ -48,14 +48,8 @@
       "firstName": "test",
       "lastName": "drive",
       "memberOnTeams": [
-        {
-          "id": 2,
-          "name": "hi hi"
-        },
-        {
-          "id": 3,
-          "name": "another one"
-        }
+        1,
+        3
       ],
       "confirmPassword": "t@g123",
       "role": "UI",
@@ -70,14 +64,8 @@
       "profileName": "ming ming",
       "lastName": "ming",
       "memberOnTeams": [
-        {
-          "id": 2,
-          "name": "hi hi"
-        },
-        {
-          "id": 3,
-          "name": "another one"
-        }
+        1,
+        2
       ],
       "confirmPassword": "ming123",
       "role": "FE",
@@ -87,33 +75,21 @@
   ],
   "teams": [
     {
-      "teamName": "skrr",
-      "dateEstd": "2020-12-29T18:00:00.000Z",
+      "teamName": "skkrrraa",
+      "dateEstd": "2020-12-23T18:00:00.000Z",
       "teamLead": {
-        "email": "t@g.com",
-        "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
-        "firstName": "test",
-        "lastName": "drive",
+        "email": "ming@ming.com",
+        "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
+        "firstName": "ming",
+        "profileName": "ming ming",
+        "lastName": "ming",
         "memberOnTeams": [],
-        "confirmPassword": "t@g123",
-        "role": "UI",
-        "profileName": "test drive",
+        "confirmPassword": "ming123",
+        "role": "FE",
         "approved": true,
-        "id": 4
+        "id": 5
       },
       "teamMembers": [
-        {
-          "email": "ming@ming.com",
-          "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
-          "firstName": "ming",
-          "profileName": "ming ming",
-          "lastName": "ming",
-          "memberOnTeams": [],
-          "confirmPassword": "ming123",
-          "role": "FE",
-          "approved": true,
-          "id": 5
-        },
         {
           "email": "t@g.com",
           "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
@@ -125,13 +101,37 @@
           "profileName": "test drive",
           "approved": true,
           "id": 4
+        },
+        {
+          "email": "g@g.com",
+          "password": "$2a$10$mXA2Q2Z2PiLZ5JNe6V0vKOMxUK4pwDRzWWGFFzCOUt.x6aj.CXdyi",
+          "memberOnTeams": [],
+          "firstName": "g",
+          "lastName": "g",
+          "confirmPassword": "g12345",
+          "role": "FE",
+          "profileName": "g g",
+          "approved": true,
+          "id": 3
+        },
+        {
+          "email": "ming@ming.com",
+          "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
+          "firstName": "ming",
+          "profileName": "ming ming",
+          "lastName": "ming",
+          "memberOnTeams": [],
+          "confirmPassword": "ming123",
+          "role": "FE",
+          "approved": true,
+          "id": 5
         }
       ],
       "id": 1
     },
     {
-      "teamName": "hi hi",
-      "dateEstd": "2020-12-22T18:00:00.000Z",
+      "teamName": "gooble",
+      "dateEstd": "2020-12-23T18:00:00.000Z",
       "teamLead": {
         "email": "ming@ming.com",
         "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
@@ -148,18 +148,16 @@
       },
       "teamMembers": [
         {
-          "email": "t@g.com",
-          "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
-          "firstName": "test",
-          "lastName": "drive",
-          "memberOnTeams": [
-            1
-          ],
-          "confirmPassword": "t@g123",
-          "role": "UI",
-          "profileName": "test drive",
+          "email": "kzoeps@gmail.com",
+          "password": "$2a$10$WntzJaL4ktLQcHPkXqQPtuflS0uC0h40G50olp1INXNJLaOUjRgoC",
+          "firstName": "karma",
+          "profileName": "karma yoezer",
+          "lastName": "yoezer",
+          "confirmPassword": "kzoeps123",
+          "role": "FE",
+          "memberOnTeams": [],
           "approved": true,
-          "id": 4
+          "id": 1
         },
         {
           "email": "ming@ming.com",
@@ -179,72 +177,50 @@
       "id": 2
     },
     {
-      "teamName": "another one",
-      "dateEstd": "2020-12-30T18:00:00.000Z",
+      "teamName": "bloop",
+      "dateEstd": "2020-12-17T18:00:00.000Z",
       "teamLead": {
-        "email": "t@g.com",
-        "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
-        "firstName": "test",
-        "lastName": "drive",
+        "email": "kzoeps@gmail.com",
+        "password": "$2a$10$WntzJaL4ktLQcHPkXqQPtuflS0uC0h40G50olp1INXNJLaOUjRgoC",
+        "firstName": "karma",
+        "profileName": "karma yoezer",
+        "lastName": "yoezer",
+        "confirmPassword": "kzoeps123",
+        "role": "FE",
         "memberOnTeams": [
-          {
-            "id": 2,
-            "name": "hi hi"
-          }
+          2
         ],
-        "confirmPassword": "t@g123",
-        "role": "UI",
-        "profileName": "test drive",
         "approved": true,
-        "id": 4
+        "id": 1
       },
       "teamMembers": [
-        {
-          "email": "karma@yoezer.com",
-          "password": "$2a$10$3Urk9KRS00qM4XDFCtwbbuBI7ypgnzgdC5qbx3.5GmYMK.RWKGKLO",
-          "firstName": "karma",
-          "profileName": "karma yowzer",
-          "lastName": "yoezer",
-          "confirmPassword": "karma123",
-          "role": "FE",
-          "memberOnTeams": [],
-          "approved": true,
-          "admin": true,
-          "id": 2
-        },
-        {
-          "email": "ming@ming.com",
-          "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
-          "firstName": "ming",
-          "profileName": "ming ming",
-          "lastName": "ming",
-          "memberOnTeams": [
-            {
-              "id": 2,
-              "name": "hi hi"
-            }
-          ],
-          "confirmPassword": "ming123",
-          "role": "FE",
-          "approved": true,
-          "id": 5
-        },
         {
           "email": "t@g.com",
           "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
           "firstName": "test",
           "lastName": "drive",
           "memberOnTeams": [
-            {
-              "id": 2,
-              "name": "hi hi"
-            }
+            1
           ],
           "confirmPassword": "t@g123",
           "role": "UI",
           "profileName": "test drive",
           "approved": true,
           "id": 4
+        },
+        {
+          "email": "kzoeps@gmail.com",
+          "password": "$2a$10$WntzJaL4ktLQcHPkXqQPtuflS0uC0h40G50olp1INXNJLaOUjRgoC",
+          "firstName": "karma",
+          "profileName": "karma yoezer",
+          "lastName": "yoezer",
+          "confirmPassword": "kzoeps123",
+          "role": "FE",
+          "memberOnTeams": [
+            2
+          ],
+          "approved": true,
+          "id": 1
         }
       ],
       "id": 3

--- a/db.json
+++ b/db.json
@@ -20,7 +20,12 @@
       "lastName": "yoezer",
       "confirmPassword": "karma123",
       "role": "FE",
-      "memberOnTeams": [],
+      "memberOnTeams": [
+        {
+          "id": 3,
+          "name": "another one"
+        }
+      ],
       "approved": true,
       "admin": true,
       "id": 2
@@ -46,6 +51,10 @@
         {
           "id": 2,
           "name": "hi hi"
+        },
+        {
+          "id": 3,
+          "name": "another one"
         }
       ],
       "confirmPassword": "t@g123",
@@ -64,6 +73,10 @@
         {
           "id": 2,
           "name": "hi hi"
+        },
+        {
+          "id": 3,
+          "name": "another one"
         }
       ],
       "confirmPassword": "ming123",
@@ -164,6 +177,77 @@
         }
       ],
       "id": 2
+    },
+    {
+      "teamName": "another one",
+      "dateEstd": "2020-12-30T18:00:00.000Z",
+      "teamLead": {
+        "email": "t@g.com",
+        "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
+        "firstName": "test",
+        "lastName": "drive",
+        "memberOnTeams": [
+          {
+            "id": 2,
+            "name": "hi hi"
+          }
+        ],
+        "confirmPassword": "t@g123",
+        "role": "UI",
+        "profileName": "test drive",
+        "approved": true,
+        "id": 4
+      },
+      "teamMembers": [
+        {
+          "email": "karma@yoezer.com",
+          "password": "$2a$10$3Urk9KRS00qM4XDFCtwbbuBI7ypgnzgdC5qbx3.5GmYMK.RWKGKLO",
+          "firstName": "karma",
+          "profileName": "karma yowzer",
+          "lastName": "yoezer",
+          "confirmPassword": "karma123",
+          "role": "FE",
+          "memberOnTeams": [],
+          "approved": true,
+          "admin": true,
+          "id": 2
+        },
+        {
+          "email": "ming@ming.com",
+          "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
+          "firstName": "ming",
+          "profileName": "ming ming",
+          "lastName": "ming",
+          "memberOnTeams": [
+            {
+              "id": 2,
+              "name": "hi hi"
+            }
+          ],
+          "confirmPassword": "ming123",
+          "role": "FE",
+          "approved": true,
+          "id": 5
+        },
+        {
+          "email": "t@g.com",
+          "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
+          "firstName": "test",
+          "lastName": "drive",
+          "memberOnTeams": [
+            {
+              "id": 2,
+              "name": "hi hi"
+            }
+          ],
+          "confirmPassword": "t@g123",
+          "role": "UI",
+          "profileName": "test drive",
+          "approved": true,
+          "id": 4
+        }
+      ],
+      "id": 3
     }
   ],
   "audits": []

--- a/db.json
+++ b/db.json
@@ -16,7 +16,7 @@
       "email": "karma@yoezer.com",
       "password": "$2a$10$3Urk9KRS00qM4XDFCtwbbuBI7ypgnzgdC5qbx3.5GmYMK.RWKGKLO",
       "firstName": "karma",
-      "profileName": "karma yoezer",
+      "profileName": "karma yowzer",
       "lastName": "yoezer",
       "confirmPassword": "karma123",
       "role": "FE",
@@ -43,7 +43,10 @@
       "firstName": "test",
       "lastName": "drive",
       "memberOnTeams": [
-        1
+        {
+          "id": 2,
+          "name": "hi hi"
+        }
       ],
       "confirmPassword": "t@g123",
       "role": "UI",
@@ -58,7 +61,10 @@
       "profileName": "ming ming",
       "lastName": "ming",
       "memberOnTeams": [
-        1
+        {
+          "id": 2,
+          "name": "hi hi"
+        }
       ],
       "confirmPassword": "ming123",
       "role": "FE",
@@ -109,6 +115,55 @@
         }
       ],
       "id": 1
+    },
+    {
+      "teamName": "hi hi",
+      "dateEstd": "2020-12-22T18:00:00.000Z",
+      "teamLead": {
+        "email": "ming@ming.com",
+        "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
+        "firstName": "ming",
+        "profileName": "ming ming",
+        "lastName": "ming",
+        "memberOnTeams": [
+          1
+        ],
+        "confirmPassword": "ming123",
+        "role": "FE",
+        "approved": true,
+        "id": 5
+      },
+      "teamMembers": [
+        {
+          "email": "t@g.com",
+          "password": "$2a$10$osZPH9zwiQiTGY0FmOwrRu/pH8jCqxOVUoEXz4202zMdllxPhYZgO",
+          "firstName": "test",
+          "lastName": "drive",
+          "memberOnTeams": [
+            1
+          ],
+          "confirmPassword": "t@g123",
+          "role": "UI",
+          "profileName": "test drive",
+          "approved": true,
+          "id": 4
+        },
+        {
+          "email": "ming@ming.com",
+          "password": "$2a$10$astTJEIofrbgbXFzHk3aLubEF7lleRg1b/EBaUM1qKIAn904Vy0m6",
+          "firstName": "ming",
+          "profileName": "ming ming",
+          "lastName": "ming",
+          "memberOnTeams": [
+            1
+          ],
+          "confirmPassword": "ming123",
+          "role": "FE",
+          "approved": true,
+          "id": 5
+        }
+      ],
+      "id": 2
     }
   ],
   "audits": []

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
     '<rootDir>/libs/feature/audit',
     '<rootDir>/libs/feature/team',
     '<rootDir>/libs/feature/auth',
+    '<rootDir>/libs/feature/shared',
   ],
 };

--- a/libs/feature/shared/README.md
+++ b/libs/feature/shared/README.md
@@ -1,0 +1,7 @@
+# shared
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test shared` to execute the unit tests.

--- a/libs/feature/shared/jest.config.js
+++ b/libs/feature/shared/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'shared',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer',
+        ],
+      },
+    },
+  },
+  coverageDirectory: '../../../coverage/libs/feature/shared',
+  snapshotSerializers: [
+    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+    'jest-preset-angular/build/AngularSnapshotSerializer.js',
+    'jest-preset-angular/build/HTMLCommentSerializer.js',
+  ],
+};

--- a/libs/feature/shared/src/index.ts
+++ b/libs/feature/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/shared.module';
+export { SharedServiceService } from './lib/services/shared-service.service';

--- a/libs/feature/shared/src/lib/services/shared-service.service.spec.ts
+++ b/libs/feature/shared/src/lib/services/shared-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SharedServiceService } from './shared-service.service';
+
+describe('SharedServiceService', () => {
+  let service: SharedServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SharedServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/feature/shared/src/lib/services/shared-service.service.ts
+++ b/libs/feature/shared/src/lib/services/shared-service.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { User } from '@selise-start/user';
+import { Team } from '@selise-start/team';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SharedServiceService {
+
+  private usersURL = 'http://localhost:3000/users';
+  private teamsURL = 'http://localhost:3000/teams';
+  httpOptions = {
+    headers: new HttpHeaders({
+      'Authorization': 'Bearer '+this.getToken(),
+      'Content-Type': 'application/json'
+    })
+  };
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  getToken(): Object|'' {
+    const user = JSON.parse(localStorage.getItem('user'));
+    if (user) {
+      return user.token;
+    } else {
+      return ''
+    }
+  }
+
+  getUsers(): Observable<User[]>{
+    return this.http.get<User[]>(this.usersURL, this.httpOptions);
+  }
+
+  getUser(user: User): Observable<User> {
+    const usersURL = `${this.usersURL}/${user.id}`;
+    return this.http.get<User>(usersURL, this.httpOptions);
+  }
+
+  updateUser(user: User): Observable<User> {
+    const url = `${this.usersURL}/${user.id}`;
+    return this.http.patch<User>(url,user,this.httpOptions);
+  }
+
+  getTeam(id: number): Observable<Team> {
+    const url = `${this.teamsURL}/${id}`;
+    return this.http.get<Team>(url, this.httpOptions);
+  }
+
+  getTeams(): Observable<Team[]> {
+    return this.http.get<Team[]>(this.teamsURL, this.httpOptions);
+  }
+}

--- a/libs/feature/shared/src/lib/services/shared-service.service.ts
+++ b/libs/feature/shared/src/lib/services/shared-service.service.ts
@@ -34,8 +34,8 @@ export class SharedServiceService {
     return this.http.get<User[]>(this.usersURL, this.httpOptions);
   }
 
-  getUser(user: User): Observable<User> {
-    const usersURL = `${this.usersURL}/${user.id}`;
+  getUser(id: number): Observable<User> {
+    const usersURL = `${this.usersURL}/${id}`;
     return this.http.get<User>(usersURL, this.httpOptions);
   }
 

--- a/libs/feature/shared/src/lib/shared.module.ts
+++ b/libs/feature/shared/src/lib/shared.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class SharedModule {}

--- a/libs/feature/shared/src/test-setup.ts
+++ b/libs/feature/shared/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/feature/shared/tsconfig.json
+++ b/libs/feature/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/feature/shared/tsconfig.lib.json
+++ b/libs/feature/shared/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/feature/shared/tsconfig.spec.json
+++ b/libs/feature/shared/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/feature/shared/tslint.json
+++ b/libs/feature/shared/tslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tslint.json",
+  "rules": {
+    "directive-selector": [true, "attribute", "seliseStart", "camelCase"],
+    "component-selector": [true, "element", "selise-start", "kebab-case"]
+  },
+  "linterOptions": {
+    "exclude": ["!**/*"]
+  }
+}

--- a/libs/feature/team/src/lib/components/add-team/add-team.component.ts
+++ b/libs/feature/team/src/lib/components/add-team/add-team.component.ts
@@ -59,9 +59,6 @@ export class AddTeamComponent implements OnInit {
           untilDestroyed(this)
         )
         .subscribe({
-          next: (whatIsthis) => {
-            console.log(whatIsthis)
-          },
           complete: () => {
             this.teamFacadeService.snackBar('Created Team');
             this.teamFacadeService.clearForm(this.addTeamForm);

--- a/libs/feature/team/src/lib/components/add-team/add-team.component.ts
+++ b/libs/feature/team/src/lib/components/add-team/add-team.component.ts
@@ -60,7 +60,6 @@ export class AddTeamComponent implements OnInit {
         )
         .subscribe({
           complete: () => {
-            // TODO: Remove team members from teamstate;
             this.teamFacadeService.snackBar('Created Team');
             this.teamFacadeService.clearForm(this.addTeamForm);
             this.createTeamSuccess = true;

--- a/libs/feature/team/src/lib/components/add-team/add-team.component.ts
+++ b/libs/feature/team/src/lib/components/add-team/add-team.component.ts
@@ -60,6 +60,7 @@ export class AddTeamComponent implements OnInit {
         )
         .subscribe({
           complete: () => {
+            // TODO: Remove team members from teamstate;
             this.teamFacadeService.snackBar('Created Team');
             this.teamFacadeService.clearForm(this.addTeamForm);
             this.createTeamSuccess = true;

--- a/libs/feature/team/src/lib/services/team-facade.service.ts
+++ b/libs/feature/team/src/lib/services/team-facade.service.ts
@@ -64,7 +64,11 @@ export class TeamFacadeService {
     return this.teamApiService.createTeam(team).pipe(
       tap((teamState)=> {
         // TODO: Subscription within subscription!
-        this.addTeamToUsers(team.teamMembers, teamState.id)
+        const teamObjectUser = {
+          id: teamState.id,
+          name: teamState.teamName
+        }
+        this.addTeamToUsers(team.teamMembers, teamObjectUser)
         team.teamMembers.forEach((eachMember) => {
           this.userFacadeService.updateUser(eachMember)
             .pipe(untilDestroyed(this))
@@ -74,9 +78,9 @@ export class TeamFacadeService {
     );
   }
 
-  addTeamToUsers(users: User[], teamID: number): void{
+  addTeamToUsers(users: User[], teamObject: Object): void{
     users.map((eachUser) => {
-      eachUser.memberOnTeams.push(teamID);
+      eachUser.memberOnTeams.push(teamObject);
     })
   }
 

--- a/libs/feature/team/src/lib/services/team-facade.service.ts
+++ b/libs/feature/team/src/lib/services/team-facade.service.ts
@@ -9,8 +9,8 @@ import { FormGroup } from '@angular/forms';
 // @ts-ignore
 import { User } from '@selise-start/user';
 import { MatSnackBar, MatSnackBarRef, TextOnlySnackBar } from '@angular/material/snack-bar';
-import { UserFacadeService } from '@selise-start/user/service';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { SharedServiceService } from '@selise-start/shared';
 
 @UntilDestroy()
 @Injectable({
@@ -24,7 +24,7 @@ export class TeamFacadeService {
     private teamStateService: TeamStateService,
     private teamFormService: TeamFormService,
     private _snackBar: MatSnackBar,
-    private userFacadeService: UserFacadeService
+    private sharedServiceService: SharedServiceService
   ) {
   }
 
@@ -70,7 +70,7 @@ export class TeamFacadeService {
         }
         this.addTeamToUsers(team.teamMembers, teamObjectUser)
         team.teamMembers.forEach((eachMember) => {
-          this.userFacadeService.updateUser(eachMember)
+          this.sharedServiceService.updateUser(eachMember)
             .pipe(untilDestroyed(this))
             .subscribe()
         })

--- a/libs/feature/user/src/index.ts
+++ b/libs/feature/user/src/index.ts
@@ -2,5 +2,6 @@ export * from './lib/feature-user.module';
 export { UsersComponent } from './lib/components/users/users.component';
 export { UserDetailComponent } from './lib/components/user-detail/user-detail.component';
 export { User } from './lib/models/user';
-export { AddUserComponent } from './lib/components/add-user/add-user.component'
+export { AddUserComponent } from './lib/components/add-user/add-user.component';
 export { AdminApprovalComponent } from './lib/components/admin-approval/admin-approval.component';
+export { EditUserComponent } from './lib/components/edit-user/edit-user.component';

--- a/libs/feature/user/src/lib/components/edit-user/edit-user.component.html
+++ b/libs/feature/user/src/lib/components/edit-user/edit-user.component.html
@@ -1,0 +1,42 @@
+<span *ngIf="(userState$ |async).userState as user">
+  <h1>Edit {{user.profileName}}</h1>
+  <form [formGroup]="editUserForm" style="display: flex; flex-direction: column">
+    <mat-form-field appearance="outline">
+      <mat-label>
+        First Name
+      </mat-label>
+      <input matInput placeholder="Ex.Kam" formControlName="firstName">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>
+        Last Name
+      </mat-label>
+      <input matInput placeholder="ex. yoez" formControlName="lastName">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>
+        Profile Name
+      </mat-label>
+      <input matInput placeholder="ex. ky" formControlName="profileName">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>
+        Email
+      </mat-label>
+      <input matInput placeholder="ex.g@gm.com" formControlName="email">
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>
+        Role
+      </mat-label>
+      <mat-select formControlName="role">
+        <mat-option *ngFor="let role of roles" [value]="role">
+          {{role}}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button mat-flat-button color="primary" (click)="updateUser()">
+      Update
+    </button>
+  </form>
+</span>

--- a/libs/feature/user/src/lib/components/edit-user/edit-user.component.spec.ts
+++ b/libs/feature/user/src/lib/components/edit-user/edit-user.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditUserComponent } from './edit-user.component';
+
+describe('EditUserComponent', () => {
+  let component: EditUserComponent;
+  let fixture: ComponentFixture<EditUserComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EditUserComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/feature/user/src/lib/components/edit-user/edit-user.component.ts
+++ b/libs/feature/user/src/lib/components/edit-user/edit-user.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { UserFacadeService } from '@selise-start/user/service';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Observable } from 'rxjs';
+import { UserStoreState } from '../../models/user';
+import { FORM_TYPES, ROLES } from '../../constants/constants';
+import { FormGroup } from '@angular/forms';
+import { tap } from 'rxjs/operators';
+
+@UntilDestroy()
+@Component({
+  selector: 'selise-start-edit-user',
+  templateUrl: './edit-user.component.html',
+  styleUrls: ['./edit-user.component.css']
+})
+export class EditUserComponent implements OnInit {
+
+  userState$: Observable<UserStoreState>;
+  editUserForm: FormGroup;
+  roles = ROLES
+
+  constructor(
+    private route: ActivatedRoute,
+    private userFacadeService: UserFacadeService
+  ) { }
+
+  ngOnInit(): void {
+    this.initializer()
+  }
+
+  initializer(): void{
+    const id = +this.route.snapshot.paramMap.get('id');
+    this.getUser(id);
+    this.createForm();
+  }
+
+  createForm(): void{
+    this.editUserForm = this.userFacadeService.createForm(FORM_TYPES.EDITUSERFORM);
+  }
+
+  getUser(id: number): void {
+    this.userFacadeService.getUser(id)
+      .pipe(
+        untilDestroyed(this),
+        tap((user) => {
+          this.userFacadeService.setForm(this.editUserForm, user);
+        })
+      )
+      .subscribe()
+    this.userState$ = this.userFacadeService.stateChange();
+  }
+
+  updateUser(): void{
+    if (this.editUserForm.valid) {
+      this.userFacadeService.updateUser(this.editUserForm.value)
+        .pipe()
+        .subscribe({
+          complete: () => {
+            this.userFacadeService.snackBar('User Updated')
+          }
+        })
+    }
+  }
+}

--- a/libs/feature/user/src/lib/components/user-detail/user-detail.component.html
+++ b/libs/feature/user/src/lib/components/user-detail/user-detail.component.html
@@ -28,13 +28,16 @@
       Role: {{user.role}}
     </mat-card-content>
   </mat-card>
-  <mat-card style="margin-top: 10px;">
+  <mat-card style="margin-top: 10px;" *ngIf="(storeState$ | async).teams as teams">
     <mat-card-title>
       Teams
     </mat-card-title>
-    <mat-card *ngFor="let team of user.memberOnTeams" style="margin-top: 10px">
-      <mat-card-content>
-        {{team.name}}
+    <mat-card *ngFor="let team of teams" style="margin-top: 10px">
+      <mat-card-content style="display: flex; justify-content: space-between">
+        {{team.teamName}}
+        <span *ngIf="team.teamLead.id === user.id">
+          Team Lead
+        </span>
       </mat-card-content>
     </mat-card>
   </mat-card>

--- a/libs/feature/user/src/lib/components/user-detail/user-detail.component.html
+++ b/libs/feature/user/src/lib/components/user-detail/user-detail.component.html
@@ -2,64 +2,40 @@
 <ng-container *ngIf="(storeState$ | async).userState as user">
   <h1>{{user.profileName | titlecase}} Details</h1>
   <hr/>
-  <form [formGroup]="userDetailForm">
     <h4>User ID: {{user.id}}</h4>
-    <mat-form-field appearance="outline">
-      <mat-label>First Name</mat-label>
-      <input matInput placeholder="Ex. Karma" formControlName="firstName">
-    </mat-form-field>
-    <br/>
-    <span *ngIf="!userDetailForm.controls.firstName.valid">
-      <span *ngIf="userDetailForm.controls.firstName.errors.required">
-        First Name required!
-      </span>
-    </span>
-    <br/>
-    <mat-form-field appearance="outline">
-      <mat-label>Last Name</mat-label>
-      <input matInput placeholder="Ex. Yoezer" formControlName="lastName" type="text">
-    </mat-form-field>
-    <br/>
-    <span *ngIf="!userDetailForm.controls.lastName.valid">
-      <span *ngIf="userDetailForm.controls.lastName.errors.required">
-        Last Name required!
-      </span>
-    </span>
-    <br/>
-    <mat-form-field appearance="outline">
-      <mat-label>Profile Name</mat-label>
-      <input matInput placeholder="Ex. Kzoeps" formControlName="profileName" type="text">
-    </mat-form-field>
-    <br/>
-    <span *ngIf="!userDetailForm.controls.profileName.valid">
-      <span
-        *ngIf="userDetailForm.controls.profileName.errors.required">
-        Profile Name Is Required!
-    </span>
-    </span>
-    <br/>
-    <mat-form-field appearance="outline">
-      <mat-label>Email</mat-label>
-      <input id="email" matInput placeholder="Ex. abc@ab.com" formControlName="email" type="email">
-    </mat-form-field>
-    <br/>
-    <span *ngIf="!userDetailForm.controls.email.valid">
-      <span *ngIf="userDetailForm.controls.email.errors.required">
-        Email Is Required!
-      </span>
-      <span *ngIf="userDetailForm.controls.email.errors.email">
-        Invalid Email Format!
-      </span>
-    </span>
-    <br/>
-    <mat-form-field appearance="outline">
-      <mat-label>Role</mat-label>
-      <mat-select [compareWith]="byRole" value="{{user.role}}" formControlName="role">
-        <mat-option *ngFor="let role of roles" value="{{role}}">{{role}}</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <br/>
-    <br/>
-    <button mat-flat-button color="primary" (click)="updateUser()">Submit</button>
-  </form>
+  <mat-card style="margin-top: 30px;">
+    <mat-card-content>
+      First Name: {{user.firstName}}
+    </mat-card-content>
+  </mat-card>
+  <mat-card style="margin-top: 30px;">
+    <mat-card-content>
+      Last Name: {{user.lastName}}
+    </mat-card-content>
+  </mat-card>
+  <mat-card style="margin-top: 30px;">
+    <mat-card-content>
+      Profile Name: {{user.profileName}}
+    </mat-card-content>
+  </mat-card>
+  <mat-card style="margin-top: 30px;">
+    <mat-card-content>
+      Email : {{user.email}}
+    </mat-card-content>
+  </mat-card>
+  <mat-card style="margin-top: 30px;">
+    <mat-card-content>
+      Role: {{user.role}}
+    </mat-card-content>
+  </mat-card>
+  <mat-card style="margin-top: 10px;">
+    <mat-card-title>
+      Teams
+    </mat-card-title>
+    <mat-card *ngFor="let team of user.memberOnTeams" style="margin-top: 10px">
+      <mat-card-content>
+        {{team.name}}
+      </mat-card-content>
+    </mat-card>
+  </mat-card>
 </ng-container>

--- a/libs/feature/user/src/lib/components/user-detail/user-detail.component.ts
+++ b/libs/feature/user/src/lib/components/user-detail/user-detail.component.ts
@@ -4,14 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { UserFacadeService } from '../../services/user-facade.service';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
-import { UserFormService } from '../../services/user-form.service';
-import { tap } from 'rxjs/operators';
-import { ROLES } from '../../constants/constants';
-import { FormGroup } from '@angular/forms';
-import { MatSnackBar } from '@angular/material/snack-bar';
 
-// COMMENT: Potentially remove the store stateChange(); because we always need to be getting the user
-// TODO: Remove the use of form service and have it talk through facade.!!!! Also the use of snackbar
 @UntilDestroy()
 @Component({
   selector: 'selise-start-user-detail',
@@ -20,52 +13,25 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class UserDetailComponent implements OnInit {
   storeState$: Observable<UserStoreState>;
-  userDetailForm: FormGroup;
-  roles = ROLES;
 
   constructor(
     private route: ActivatedRoute,
     private userFacadeService: UserFacadeService,
-    private userFormService: UserFormService,
-    private _snackBar: MatSnackBar
   ) {
   }
 
   ngOnInit(): void {
     const id = +this.route.snapshot.paramMap.get('id');
     this.getUser(id);
-    // this.userDetailForm = this.userFormService.createForm();
   }
 
   getUser(id: number): void {
     this.userFacadeService.getUser(id)
       .pipe(
         untilDestroyed(this),
-        tap(user => {
-          this.userFormService.setForm(this.userDetailForm, user);
-        })
       )
-      .subscribe();
+      .subscribe()
     this.storeState$ = this.userFacadeService.stateChange();
   }
 
-  byRole(role: string, userRole: string): boolean {
-    return userRole === role;
-  }
-
-  updateUser(): void {
-    console.log(this.userDetailForm.valid);
-    if (this.userDetailForm.valid) {
-      const user = this.userDetailForm.value;
-      this.userFacadeService.updateUser(user)
-        .pipe(untilDestroyed(this))
-        .subscribe({
-          complete: () => {
-            this._snackBar.open('Updated Successfully', '', {
-              duration: 2000
-            });
-          }
-        });
-    }
-  }
 }

--- a/libs/feature/user/src/lib/components/user-detail/user-detail.component.ts
+++ b/libs/feature/user/src/lib/components/user-detail/user-detail.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { UserStoreState } from '../../models/user';
+import { User, UserStoreState } from '../../models/user';
 import { ActivatedRoute } from '@angular/router';
-import { UserFacadeService } from '../../services/user-facade.service';
+import { UserFacadeService } from '@selise-start/user/service';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
-import { Observable } from 'rxjs';
+import { forkJoin, Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Team } from '@selise-start/team';
 
 @UntilDestroy()
 @Component({
@@ -26,12 +28,11 @@ export class UserDetailComponent implements OnInit {
   }
 
   getUser(id: number): void {
-    this.userFacadeService.getUser(id)
+    this.userFacadeService.getUserWithTeam(id)
       .pipe(
         untilDestroyed(this),
       )
       .subscribe()
     this.storeState$ = this.userFacadeService.stateChange();
   }
-
 }

--- a/libs/feature/user/src/lib/constants/constants.ts
+++ b/libs/feature/user/src/lib/constants/constants.ts
@@ -1,15 +1,32 @@
 import { Validators } from '@angular/forms';
 
-export const USER_FORM = [
-  'id',
-  'firstName',
-  'lastName',
-  'profileName',
-  'email',
-  'role',
-  'password',
-  'confirmPassword',
-];
+export const EDIT_USER_FORM = {
+  id: {
+    validators: [Validators.required],
+    value: '',
+  },
+  firstName: {
+    validators: [Validators.required],
+    value: ''
+  },
+  lastName: {
+    validators: [Validators.required],
+    value: ''
+  },
+  email: {
+    validators: [Validators.required, Validators.email],
+    value: ''
+  },
+  profileName: {
+    validators: [Validators.required, Validators.minLength(6)],
+    value: ''
+  },
+  role: {
+    validators: [Validators.required],
+    value: ''
+  }
+}
+
 
 export const ADD_USER_FORM = {
   firstName: {

--- a/libs/feature/user/src/lib/feature-user.module.ts
+++ b/libs/feature/user/src/lib/feature-user.module.ts
@@ -13,6 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { AddUserComponent } from './components/add-user/add-user.component';
 import { AdminApprovalComponent } from './components/admin-approval/admin-approval.component';
 import { MatCardModule } from '@angular/material/card';
+import { EditUserComponent } from './components/edit-user/edit-user.component';
 
 @NgModule({
   imports: [
@@ -28,7 +29,7 @@ import { MatCardModule } from '@angular/material/card';
     MatButtonModule,
     MatCardModule
   ],
-  declarations: [UserDetailComponent, UsersComponent, AddUserComponent, AdminApprovalComponent],
-  exports: [UserDetailComponent, UsersComponent, AddUserComponent, AdminApprovalComponent],
+  declarations: [UserDetailComponent, UsersComponent, AddUserComponent, AdminApprovalComponent, EditUserComponent],
+  exports: [UserDetailComponent, UsersComponent, AddUserComponent, AdminApprovalComponent, EditUserComponent],
 })
 export class FeatureUserModule {}

--- a/libs/feature/user/src/lib/models/user.ts
+++ b/libs/feature/user/src/lib/models/user.ts
@@ -8,7 +8,7 @@ export class User {
   confirmPassword: string;
   role: string;
   leadOnTeams: string[];
-  memberOnTeams: number[];
+  memberOnTeams: Object[];
   admin: boolean;
   approved: boolean;
   token: string;

--- a/libs/feature/user/src/lib/models/user.ts
+++ b/libs/feature/user/src/lib/models/user.ts
@@ -1,3 +1,5 @@
+import { Team } from '@selise-start/team';
+
 export class User {
   id: number;
   firstName: string;
@@ -28,5 +30,6 @@ export class User {
 export interface UserStoreState {
   usersState: User[];
   userState: User;
+  teams: Team[];
 }
 

--- a/libs/feature/user/src/lib/models/user.ts
+++ b/libs/feature/user/src/lib/models/user.ts
@@ -10,7 +10,7 @@ export class User {
   confirmPassword: string;
   role: string;
   leadOnTeams: string[];
-  memberOnTeams: Object[];
+  memberOnTeams: number[];
   admin: boolean;
   approved: boolean;
   token: string;

--- a/libs/feature/user/src/lib/services/user-facade.service.ts
+++ b/libs/feature/user/src/lib/services/user-facade.service.ts
@@ -5,7 +5,7 @@ import { User, UserStoreState } from '../models/user';
 import { map, tap } from 'rxjs/operators';
 import { UserStateService } from './user-state.service';
 import { FormGroup } from '@angular/forms';
-import { ADD_USER_FORM, FORM_TYPES } from '../constants/constants';
+import { ADD_USER_FORM, EDIT_USER_FORM, FORM_TYPES } from '../constants/constants';
 import { UserFormService } from './user-form.service';
 import { MatSnackBar, MatSnackBarRef, TextOnlySnackBar } from '@angular/material/snack-bar';
 
@@ -69,6 +69,8 @@ export class UserFacadeService {
         const userForm = this.userFormService.createForm(ADD_USER_FORM);
         this.userFormService.setMatchingPasswordValidator(userForm.controls['confirmPassword'], userForm.controls['password']);
         return userForm;
+      case FORM_TYPES.EDITUSERFORM:
+        return this.userFormService.createForm(EDIT_USER_FORM);
     }
   }
 
@@ -94,8 +96,12 @@ export class UserFacadeService {
     return this.userApiService.updateUser(user)
       .pipe(
         tap((approvedUser)=> {
-          this.userStateService.removeUser(user);
+          this.userStateService.removeUser(approvedUser);
         })
       )
+  }
+
+  setForm(form: FormGroup, user: User): void {
+    this.userFormService.setForm(form, user);
   }
 }

--- a/libs/feature/user/src/lib/services/user-facade.service.ts
+++ b/libs/feature/user/src/lib/services/user-facade.service.ts
@@ -70,16 +70,18 @@ export class UserFacadeService {
     return this.getUser(id).pipe(
       switchMap((user) => this.getTeams(user)
         .pipe(
-          tap((teams) => {this.userStateService.setTeam(teams)})
+          tap((teams) => {
+            this.userStateService.setTeam(teams);
+          })
         )
       )
-    )
+    );
   }
 
   getTeams(user): Observable<any> {
     return forkJoin(
-      user.memberOnTeams.map((team: Team) => this.getTeam(team.id))
-    )
+      user.memberOnTeams.map((teamID: number) => this.getTeam(teamID))
+    );
   }
 
   createForm(formType: string): FormGroup {
@@ -112,15 +114,16 @@ export class UserFacadeService {
   addTeamToState(team: Team): void {
     this.userStateService.addTeam(team);
   }
+
   approveUser(user: User): Observable<User> {
     user.approved = true;
     this.userStateService.removeUser(user);
     return this.userApiService.updateUser(user)
       .pipe(
-        tap((approvedUser)=> {
+        tap((approvedUser) => {
           this.userStateService.removeUser(approvedUser);
         })
-      )
+      );
   }
 
   setForm(form: FormGroup, user: User): void {

--- a/libs/feature/user/src/lib/services/user-form.service.ts
+++ b/libs/feature/user/src/lib/services/user-form.service.ts
@@ -1,13 +1,11 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
-import { USER_FORM } from '../constants/constants';
 import { User } from '../models/user';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserFormService {
-  formValues = USER_FORM;
   constructor( private fb: FormBuilder) {
   }
 
@@ -20,26 +18,16 @@ export class UserFormService {
     return form;
   }
 
-  setMatchingPasswordValidator(control: AbstractControl, password: AbstractControl): void {
-    control.setValidators([Validators.required, matchingPasswords(password)]);
-  }
-
-  // createForm(): FormGroup {
-  //   const userForm = this.fb.group({});
-  //   this.formValues.forEach((formValue) => {
-  //     if (formValue === 'email') {
-  //       userForm.addControl(formValue, new FormControl('',[Validators.required, Validators.email]))
-  //     } else {
-  //       userForm.addControl(formValue, new FormControl('', [Validators.required]));
-  //     }
-  //   })
-  //   return userForm;
-  // }
-
   setForm(form: FormGroup, user: User) {
     Object.keys(form.controls).forEach(controlName => {
-      form.controls[controlName].setValue(user[controlName]);
+      if (user[controlName]) {
+        form.controls[controlName].setValue(user[controlName]);
+      }
     })
+  }
+
+  setMatchingPasswordValidator(control: AbstractControl, password: AbstractControl): void {
+    control.setValidators([Validators.required, matchingPasswords(password)]);
   }
 
   validForm(form: FormGroup): boolean {

--- a/libs/feature/user/src/lib/services/user-state.service.ts
+++ b/libs/feature/user/src/lib/services/user-state.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ObservableStore } from '@codewithdan/observable-store';
 import { User, UserStoreState } from '../models/user';
+import { Team } from '@selise-start/team';
 
 @Injectable({
   providedIn: 'root'
@@ -14,8 +15,9 @@ export class UserStateService extends ObservableStore<UserStoreState> {
 
   initialState(): void {
     const initialState = {
-      usersState: undefined,
-      userState: undefined
+      usersState: [],
+      userState: new User(),
+      teams: []
     };
     this.setState(initialState, 'INIT_STATE');
   }
@@ -32,5 +34,17 @@ export class UserStateService extends ObservableStore<UserStoreState> {
     let users = this.getState().usersState;
     users = users.filter((eachUser) => user.id !== eachUser.id);
     this.setState({usersState: users});
+  }
+
+  addTeam(team: Team): void {
+    const teams = this.getState().teams;
+    teams.push(team);
+    this.setState({teams: teams});
+  }
+
+  setTeam(teams: Team[]): void {
+    let teams$ = this.getState().teams;
+    teams$ = teams;
+    this.setState({teams: teams$});
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -41,6 +41,9 @@
     },
     "auth": {
       "tags": []
+    },
+    "shared": {
+      "tags": []
     }
   },
   "workspaceLayout": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,8 @@
       ],
       "@selise-start/audit": ["libs/feature/audit/src/index.ts"],
       "@selise-start/team": ["libs/feature/team/src/index.ts"],
-      "@selise-start/auth": ["libs/feature/auth/src/index.ts"]
+      "@selise-start/auth": ["libs/feature/auth/src/index.ts"],
+      "@selise-start/shared": ["libs/feature/shared/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
1. Subscription within subscription has been removed.
   - Removed it from user-detail to get each team and updated it to state
   - Removed it from add-team. Used `forkJoin` to update each user instead of subscribing inside.
2. User-detail shows teams users are members on.
   - Shows team in cards with a field for if the user is a team lead.
   - made the team a separate field in the store. 